### PR TITLE
🚀 Use v4 publishing image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:26b720c51b12f13b91d35b4447acbb21f437cfd94e36e1581ea631955ea616ba # v3.0.2
+      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
     permissions:
       contents: read
     steps:
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          /scripts/deploy.sh
+          /usr/local/bin/package
 
   test:
     name: Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:26b720c51b12f13b91d35b4447acbb21f437cfd94e36e1581ea631955ea616ba # v3.0.2
+      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
     permissions:
       contents: read
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         id: build
         run: |
-          /scripts/deploy.sh
+          /usr/local/bin/package
 
       - name: Upload Artifact
         id: upload_artifact

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -4,7 +4,7 @@ MODE="${1:-preview}"
 TECH_DOCS_PUBLISHER_IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684" # v4.0.0
 
 case ${MODE} in
-package | preview )
+package | preview)
   true
   ;;
 *)

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 MODE="${1:-preview}"
-TECH_DOCS_PUBLISHER_IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:26b720c51b12f13b91d35b4447acbb21f437cfd94e36e1581ea631955ea616ba" # v3.0.2
+TECH_DOCS_PUBLISHER_IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684" # v4.0.0
 
 case ${MODE} in
-deploy | preview | check-url-links)
+package | preview )
   true
   ;;
 *)
-  echo "Usage: ${0} [deploy|preview|check-url-links]"
+  echo "Usage: ${0} [package|preview]"
   exit 1
   ;;
 esac
@@ -24,4 +24,4 @@ docker run -it --rm "${PLATFORM_FLAG}" \
   --publish 4567:4567 \
   --volume "${PWD}/config:/app/config" \
   --volume "${PWD}/source:/app/source" \
-  "${TECH_DOCS_PUBLISHER_IMAGE}" "/scripts/${MODE}.sh"
+  "${TECH_DOCS_PUBLISHER_IMAGE}" "/usr/local/bin/${MODE}"


### PR DESCRIPTION
This pull request:

- Updates `docker.io/ministryofjustice/tech-docs-github-pages-publisher` to v4

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 