### PR TITLE
📌 Update `tech-docs-github-pages-publisher` to v5.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
     permissions:
       contents: read
     steps:

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MODE="${1:-preview}"
-TECH_DOCS_PUBLISHER_IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684" # v4.0.0
+TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8" # v5.0.0
 
 case ${MODE} in
 package | preview)
@@ -22,6 +22,6 @@ fi
 docker run -it --rm "${PLATFORM_FLAG}" \
   --name "tech-docs-${MODE}" \
   --publish 4567:4567 \
-  --volume "${PWD}/config:/app/config" \
-  --volume "${PWD}/source:/app/source" \
+  --volume "${PWD}/config:/tech-docs-github-pages-publisher/config" \
+  --volume "${PWD}/source:/tech-docs-github-pages-publisher/source" \
   "${TECH_DOCS_PUBLISHER_IMAGE}" "/usr/local/bin/${MODE}"

--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
This pull request:

- Updates `tech-docs-github-pages-publisher` to [v5.0.0](https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/v5.0.0)
- Adds required `source/javascripts/govuk_frontend.js`
- Updates `scripts/local.sh` to use new working directory

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 