### PR TITLE
Skip failing lychee  check for operations-engineering-reports url

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 https://github.com/ministryofjustice/data-platform-support/issues
+https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/analytical-platform-user-guide


### PR DESCRIPTION

The Lychee link check is failing [here](https://github.com/ministryofjustice/analytical-platform-user-guide/actions/runs/14186832620/job/39743564491?pr=80)  in this dependabot [PR](https://github.com/ministryofjustice/analytical-platform-user-guide/pull/80) 

The link  https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/analytical-platform-user-guide the check is failing on is valid, but requires authorisation and I assume this is why the check fails, adding the url to the `lycheeignore` file as a work around.