### PR TITLE
:memo: Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,3 @@ preview:
 		--publish 4567:4567 \
 		$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE)@$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA) \
 		/usr/local/bin/preview
-
-link-check:
-	lychee --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: package preview
+
+.DEFAULT_GOAL := preview
+
+TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE     ?= ghcr.io/ministryofjustice/tech-docs-github-pages-publisher
+TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
+
+package:
+	docker run --rm \
+	    --name tech-docs-github-pages-publisher \
+	    --volume $(PWD)/config:/tech-docs-github-pages-publisher/config \
+		--volume $(PWD)/source:/tech-docs-github-pages-publisher/source \
+		$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE)@$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA) \
+		/usr/local/bin/package
+
+preview:
+	docker run -it --rm \
+	    --name tech-docs-github-pages-publisher-preview \
+	    --volume $(PWD)/config:/tech-docs-github-pages-publisher/config \
+		--volume $(PWD)/source:/tech-docs-github-pages-publisher/source \
+		--publish 4567:4567 \
+		$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE)@$(TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA) \
+		/usr/local/bin/preview
+
+link-check:
+	lychee --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MODE="${1:-preview}"
-TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8" # v5.0.0
+TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:b26b8fcba6f8feaa46a64bd96a081cb09db21daeb6d382c0f9cc370ff5b8a34a" # v6.2.0
 
 case ${MODE} in
 package | preview)


### PR DESCRIPTION
This pull request introduces improvements to the build and preview workflow for the documentation site. The main changes are the addition of a `Makefile` with Docker-based commands for packaging and previewing the site, and an update to the Docker image version used in the local script.

Build and workflow improvements:

* Added a new `Makefile` with targets for `package`, `preview`, and `link-check`, enabling easier and more consistent Docker-based workflows for building and previewing documentation.
* Updated the Docker image reference in `scripts/local.sh` to use version `v6.2.0` of `tech-docs-github-pages-publisher`, ensuring the latest features and fixes are used.