### PR TITLE
Remove lychee action and lycheeignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,3 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
-  

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+  

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,12 +22,12 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Dependency Review
         id: dependency_review
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
     permissions:
       contents: read
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload Artifact
         id: upload_artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: github-pages
           path: artifact.tar
@@ -55,8 +55,8 @@ jobs:
     steps:
       - name: Configure Pages
         id: configure_pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Deploy to GitHub Pages
         id: deploy_pages
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/screenshot-pages.yml
+++ b/.github/workflows/screenshot-pages.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Checkout PR Branch
         id: checkout_pr
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
 
       - name: Checkout Base Branch
         id: checkout_base
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           ref: ${{ github.base_ref }}
@@ -129,7 +129,7 @@ jobs:
             --volume "${GITHUB_WORKSPACE}/pr-branch/source:/tech-docs-github-pages-publisher/source" \
             --volume "${GITHUB_WORKSPACE}/pr-build:/tech-docs-github-pages-publisher/build" \
             --entrypoint /bin/sh \
-            ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 \
+            ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e \
             -c "/usr/local/bin/package && cp artifact.tar build/"
 
           mkdir -p "${GITHUB_WORKSPACE}/site-pr"
@@ -146,7 +146,7 @@ jobs:
             --volume "${GITHUB_WORKSPACE}/base-branch/source:/tech-docs-github-pages-publisher/source" \
             --volume "${GITHUB_WORKSPACE}/base-build:/tech-docs-github-pages-publisher/build" \
             --entrypoint /bin/sh \
-            ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 \
+            ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e \
             -c "/usr/local/bin/package && cp artifact.tar build/"
 
           mkdir -p "${GITHUB_WORKSPACE}/site-base"
@@ -335,7 +335,7 @@ jobs:
       - name: Upload Screenshots
         id: upload_screenshots
         if: steps.detect_changes.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: page-screenshots
           path: ${{ github.workspace }}/screenshots/
@@ -343,7 +343,7 @@ jobs:
 
       - name: Post Screenshots to PR
         if: steps.detect_changes.outputs.has_changes == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SCREENSHOT_DIR: ${{ github.workspace }}/screenshots
         with:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,14 +23,14 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Super-Linter
         id: super_linter
-        uses: super-linter/super-linter/slim@2bdd90ed3262e023ac84bf8fe35dc480721fc1f2 # v8.2.1
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CSS: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,22 +27,3 @@ jobs:
         id: build
         run: |
           /usr/local/bin/package
-
-  link-checker:
-    name: Link Checker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-
-      - name: Lychee
-        id: lychee
-        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
-        with:
-          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429,400
-          fail: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
     permissions:
       contents: read
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,0 @@
-https://github.com/ministryofjustice/data-platform-support/issues
-https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/analytical-platform-user-guide
-https://controlpanel.services.analytical-platform.service.justice.gov.uk

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MODE="${1:-preview}"
-TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:b26b8fcba6f8feaa46a64bd96a081cb09db21daeb6d382c0f9cc370ff5b8a34a" # v6.2.0
+TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e" # v6.2.0
 
 case ${MODE} in
 package | preview)


### PR DESCRIPTION
`lycheeverse/lychee-action` is now prohibited, this PR removes it and associated files.

Tracked [here](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=173547798&issue=ministryofjustice%7Canalytical-platform-security%7C25)
